### PR TITLE
Fixed revert_to_previous_leaf_state() not reverting after first itera…

### DIFF
--- a/pysm/pysm.py
+++ b/pysm/pysm.py
@@ -683,6 +683,7 @@ class StateMachine(State):
         self.set_previous_leaf_state(event)
         try:
             self.leaf_state_stack.pop()
+            self.leaf_state_stack.pop()
         except IndexError:
             return
 


### PR DESCRIPTION
…tion.

revert_to_previous_leaf_state() would revert back a single leaf_state and would loop on that leaf_state for each additional iteration of revert_to_previous_leaf_state().

Testing:
test_pysm.py passes