### PR TITLE
Fix version bump workflow

### DIFF
--- a/.github/workflows/bump-patch-version.yml
+++ b/.github/workflows/bump-patch-version.yml
@@ -34,12 +34,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          changed="false"
+          package_changed="false"
+          version_changed="false"
           while IFS= read -r file; do
             case "$file" in
+              pysm/version.py)
+                version_changed="true"
+                package_changed="true"
+                ;;
               pysm/*)
-                changed="true"
-                break
+                package_changed="true"
                 ;;
             esac
           done < <(
@@ -48,17 +52,22 @@ jobs:
               --jq '.[] | .filename, (.previous_filename // empty)'
           )
 
-          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+          echo "package_changed=$package_changed" >> "$GITHUB_OUTPUT"
+          echo "version_changed=$version_changed" >> "$GITHUB_OUTPUT"
 
       - name: Bump patch version
         id: bump
-        if: steps.package_changes.outputs.changed == 'true'
+        if: |
+          steps.package_changes.outputs.package_changed == 'true' &&
+          steps.package_changes.outputs.version_changed != 'true'
         run: |
           version="$(python .github/scripts/bump_patch_version.py)"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Commit patch bump
-        if: steps.package_changes.outputs.changed == 'true'
+        if: |
+          steps.package_changes.outputs.package_changed == 'true' &&
+          steps.package_changes.outputs.version_changed != 'true'
         run: |
           if git diff --quiet -- pysm/version.py; then
             echo "No version change detected."
@@ -72,5 +81,9 @@ jobs:
           git push origin HEAD:master
 
       - name: Skip patch bump
-        if: steps.package_changes.outputs.changed != 'true'
+        if: steps.package_changes.outputs.package_changed != 'true'
         run: echo "No files under pysm/ changed; skipping patch bump."
+
+      - name: Skip patch bump for explicit version change
+        if: steps.package_changes.outputs.version_changed == 'true'
+        run: echo "pysm/version.py changed in the merged PR; skipping automatic patch bump."

--- a/pysm/version.py
+++ b/pysm/version.py
@@ -1,2 +1,2 @@
-__version_info__ = ('0', '4', '1')
+__version_info__ = ('0', '4', '0')
 __version__ = '.'.join(__version_info__)


### PR DESCRIPTION
## Summary

- Restores the modernization release version from `0.4.1` back to `0.4.0`.
- Updates the automatic patch-bump workflow to skip bumping when the merged PR already changes `pysm/version.py`.
- Keeps the existing `pysm/**` guard so docs-only and CI-only PRs do not bump package versions.

## Validation

- `pytest -q` -> `138 passed`
- `python test/upysm_smoke.py` -> `upysm smoke ok`
- workflow YAML parse -> ok
- package change detection shell simulation -> ok
- `git diff --check` -> clean
