### PR TITLE
Document recent runtime and packaging updates

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -16,6 +16,41 @@ This is a simple state machine with only two states - `on` and `off`.
     :literal:
 
 
+Fluent builder
+--------------
+
+The optional builder module reduces setup boilerplate while still using the
+same ``StateMachine``, ``State``, and ``Event`` classes at runtime.
+
+.. code-block:: python
+
+    from pysm import Event
+    from pysm.builder import StateMachineBuilder
+
+    machine = (StateMachineBuilder('toggle')
+               .state('off', initial=True)
+               .state('on')
+               .transition('off', 'on', events='turn_on')
+               .transition('on', 'off', events='turn_off')
+               .build())
+
+    machine.dispatch(Event('turn_on'))
+    assert machine.leaf_state.name == 'on'
+
+Nested machines can be addressed by path when short state names would be
+ambiguous:
+
+.. code-block:: python
+
+    machine = (StateMachineBuilder('oven')
+               .machine('door_closed', initial=True)
+               .state('off', initial=True, parent_path='door_closed')
+               .machine('heating', parent_path='door_closed')
+               .state('baking', initial=True, parent_path='heating')
+               .transition('off', 'baking', events='bake')
+               .build())
+
+
 Complex hierarchical state machine
 ----------------------------------
 
@@ -61,6 +96,101 @@ behaves as a `Pushdown Automaton (PDA)
 
 .. include:: ../examples/rpn_calculator.py
     :literal:
+
+
+Queued dispatch
+---------------
+
+``QueuedStateMachine`` is useful when handlers may dispatch more events and
+you want deterministic run-to-completion scheduling.
+
+.. code-block:: python
+
+    from pysm import Event, State
+    from pysm.queued import QueuedStateMachine
+
+    calls = []
+    machine = QueuedStateMachine('m')
+    a = State('a')
+    b = State('b')
+
+    def enter_b(state, event):
+        calls.append('enter_b')
+        machine.dispatch(Event('finish'))
+        calls.append('enter_b_returned')
+
+    b.handlers = {'enter': enter_b}
+    machine.add_state(a, initial=True)
+    machine.add_state(b)
+    machine.add_transition(a, b, events=['go'])
+    machine.add_transition(
+        b, None, events=['finish'],
+        action=lambda state, event: calls.append('finish'))
+    machine.initialize()
+
+    machine.dispatch(Event('go'))
+    assert calls == ['enter_b', 'enter_b_returned', 'finish']
+
+
+Async dispatch
+--------------
+
+``AsyncQueuedStateMachine`` awaits async handlers, conditions, and transition
+callbacks while preserving the same callback order as the synchronous runtime.
+
+.. code-block:: python
+
+    from pysm import Event, State
+    from pysm.aio import AsyncQueuedStateMachine
+
+    async def main():
+        machine = AsyncQueuedStateMachine('m')
+        idle = State('idle')
+        ready = State('ready')
+
+        async def enter_ready(state, event):
+            await machine.dispatch(Event('validate'))
+
+        ready.handlers = {'enter': enter_ready}
+
+        machine.add_state(idle, initial=True)
+        machine.add_state(ready)
+        machine.add_transition(idle, ready, events=['go'])
+        machine.add_transition(ready, None, events=['validate'])
+        machine.initialize()
+
+        await machine.dispatch(Event('go'))
+        assert machine.leaf_state is ready
+
+
+Snapshot and restore
+--------------------
+
+The serialization helper stores active machine state as plain Python data.
+Recreate the same graph, initialize it, and then restore the snapshot.
+
+.. code-block:: python
+
+    from pysm import Event
+    from pysm.builder import StateMachineBuilder
+    from pysm.serialization import restore, snapshot
+
+    def build_toggle():
+        return (StateMachineBuilder('toggle')
+                .state('off', initial=True)
+                .state('on')
+                .transition('off', 'on', events='turn_on')
+                .transition('on', 'off', events='turn_off')
+                .build())
+
+    machine = build_toggle()
+    machine.dispatch(Event('turn_on'))
+    data = snapshot(machine, metadata={'source': 'example'})
+
+    restored = build_toggle()
+    restore(restored, data)
+
+    assert restored.leaf_state.name == 'on'
 
 
 ----

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,13 @@ Python State Machine
 ``pysm`` is a tiny, explicit hierarchical state machine library. The classic
 core remains dependency-free and suitable for small runtimes, while optional
 modules provide run-to-completion event scheduling, thread-safe dispatch,
-async dispatch, serialization, and builder ergonomics.
+async dispatch, serialization, builder ergonomics, and shipped type
+information for editors and type checkers.
+
+The core runtime still follows the original composition-first style: create
+states, add them to a root machine, add transitions, initialize the machine,
+and dispatch hashable events. Newer helpers are layered around that core
+instead of changing the top-level import.
 
 Core imports stay small:
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -1,13 +1,28 @@
 Installation
 ============
 
-Install pysm from `PyPI <https://pypi.python.org/pypi/pysm/>`_::
+``pysm`` supports Python 3.7 and newer. Install it from
+`PyPI <https://pypi.python.org/pypi/pysm/>`_::
 
-    pip install pysm
+    python -m pip install pysm
 
-or clone the `Github pysm repository <https://github.com/pgularski/pysm/>`_::
+Or clone the `Github pysm repository <https://github.com/pgularski/pysm/>`_
+and install the checkout::
 
     git clone https://github.com/pgularski/pysm
     cd pysm
-    python setup.py install
+    python -m pip install .
 
+The package includes ``py.typed`` and ``.pyi`` files, so type checkers and
+editors can use the shipped type information without an extra stub package.
+The classic ``from pysm import StateMachine, State, Event`` import remains
+dependency-free; optional runtime helpers are imported from their own modules.
+
+
+Building the documentation locally
+----------------------------------
+
+The documentation build uses Sphinx and the Read the Docs theme::
+
+    python -m pip install -r docs/requirements.txt
+    python -m sphinx -b html docs docs/_build/html

--- a/docs/optional_modules.rst
+++ b/docs/optional_modules.rst
@@ -52,6 +52,23 @@ Core vs Optional Modules
      - Development-time only
 
 
+Core Behavior Updates
+---------------------
+
+The core API is still the same explicit building-block API, but recent runtime
+hardening added a few details worth making visible:
+
+* ``dispatch()`` now raises ``StateMachineException`` if the machine has not
+  been initialized. Call ``initialize()`` on the root machine after adding all
+  states and transitions.
+* The built-in ``state_stack``, ``leaf_state_stack``, and ``stack`` on
+  ``StateMachine`` instances are bounded by ``StateMachine.STACK_SIZE``. The
+  default is ``32``. If you need an unbounded standalone stack, create
+  ``Stack(maxlen=None)`` yourself.
+* The core import does not load ``asyncio``, ``json``, ``threading``, or any of
+  the optional ``pysm.*`` helper modules.
+
+
 Initial Entry Events
 --------------------
 
@@ -75,6 +92,8 @@ opt in explicitly:
 
 For hierarchical machines, ``enter`` handlers fire from the root's initial
 child down to the active leaf state. The root machine itself is not entered.
+Queued and async machines keep the same ordering, but they drain any events
+dispatched by initial ``enter`` handlers only after the initial path is ready.
 
 
 Queued Run-To-Completion Dispatch
@@ -125,6 +144,10 @@ accidental internal event cycle:
 .. code-block:: python
 
    machine = QueuedStateMachine('m', max_internal_steps=100)
+
+If a handler, condition, or transition callback raises, the queued runtime
+clears pending internal and external work before re-raising the original
+exception. A later dispatch starts from a clean queue.
 
 
 Thread-Safe Queued Dispatch
@@ -183,6 +206,14 @@ Use ``await machine.async_initialize(fire_events_on_init=True)`` if initial
 ``enter`` handlers need to be awaited.
 
 
+Typed Packages
+--------------
+
+The distribution ships ``py.typed`` and ``.pyi`` files for the core and
+optional modules. This gives static type checkers a public API surface without
+adding runtime annotations to the MicroPython-friendly core.
+
+
 Snapshot And Restore
 --------------------
 
@@ -212,6 +243,16 @@ machine because different branches may contain states with the same name.
 Restore is strict and raises if the saved topology does not match the machine
 being restored.
 
+Pass ``metadata`` when your persistence layer needs application data next to
+the runtime state:
+
+.. code-block:: python
+
+   data = snapshot(machine, metadata={'schema': 3})
+
+The metadata is copied into the returned dictionary, but restore only uses the
+runtime fields.
+
 
 Builder
 -------
@@ -230,7 +271,21 @@ and does not add methods to your domain objects.
               .transition('on', 'off', events=['turn_off'])
               .build())
 
-For nested machines, use paths when short names would be ambiguous.
+For nested machines, use paths when short names would be ambiguous:
+
+.. code-block:: python
+
+   machine = (StateMachineBuilder('oven')
+              .machine('door_closed', initial=True)
+              .state('off', initial=True, parent_path='door_closed')
+              .machine('heating', parent_path='door_closed')
+              .state('baking', initial=True, parent_path='heating')
+              .transition('off', 'baking', events='bake')
+              .build())
+
+String ``events`` and ``input`` values are treated as one event or input value,
+not as iterables of characters. Use a list, tuple, or other iterable when a
+single transition should match many values.
 
 
 MicroPython / upysm

--- a/docs/pysm_module.rst
+++ b/docs/pysm_module.rst
@@ -1,6 +1,18 @@
 Module documentation
 ====================
 
+Public imports
+--------------
+
+The top-level package intentionally exports only the classic core runtime:
+``StateMachine``, ``State``, ``Event``, ``StateMachineException``, ``Stack``,
+``any_event``, ``AnyEvent``, ``logger``, ``__version__``, and
+``__version_info__``.
+
+Optional modules are documented below, but they are not imported by
+``import pysm``. Import them explicitly when you need their behavior.
+
+
 Core
 ----
 


### PR DESCRIPTION
## Summary
- Expand docs for the fluent builder, queued dispatch, async dispatch, and snapshot restore examples
- Clarify installation, typed package support, and the minimal top-level import surface
- Document recent core behavior changes and optional module boundaries

## Testing
- Not run (not requested)