### PR TITLE
Add release tagging to the patch bump workflow

### DIFF
--- a/.github/scripts/prepend_changelog_entry.py
+++ b/.github/scripts/prepend_changelog_entry.py
@@ -1,0 +1,150 @@
+from datetime import date
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+DEFAULT_CHANGELOG = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+"""
+
+CATEGORY_RULES = (
+    ('Security', ('security',)),
+    ('Removed', ('removed', 'removal')),
+    ('Deprecated', ('deprecated', 'deprecation')),
+    ('Added', ('added', 'feature', 'enhancement')),
+    ('Fixed', ('fixed', 'fix', 'bug')),
+    ('Documentation', ('documentation', 'docs')),
+    ('Tests', ('test', 'tests')),
+    ('CI', ('ci', 'github-actions', 'github actions')),
+)
+
+
+def normalize_label(label):
+    return str(label).strip().lower()
+
+
+def choose_category(labels):
+    normalized = [normalize_label(label) for label in labels]
+    for category, aliases in CATEGORY_RULES:
+        for label in normalized:
+            if label in aliases:
+                return category
+            if any(label.startswith(alias + ':') for alias in aliases):
+                return category
+    return 'Changed'
+
+
+def collapse_whitespace(value):
+    if value is None:
+        return ''
+    return ' '.join(str(value).split())
+
+
+def build_bullet(metadata):
+    title = collapse_whitespace(metadata.get('title')) or 'Merged pull request'
+    number = metadata.get('number')
+    url = metadata.get('html_url')
+    user = metadata.get('user') or {}
+    author = user.get('login')
+
+    pieces = [title]
+    if number and url:
+        pieces.append('([#{0}]({1}))'.format(number, url))
+    elif number:
+        pieces.append('(#{0})'.format(number))
+    if author:
+        pieces.append('by @{0}'.format(author))
+
+    return '- {0}'.format(' '.join(pieces))
+
+
+def build_entries(version, release_date, metadata):
+    tag = 'v{0}'.format(version)
+    labels = [label.get('name', '') for label in metadata.get('labels') or []]
+    category = choose_category(labels)
+    bullet = build_bullet(metadata)
+    changelog_entry = (
+        '## [{tag}] - {release_date}\n\n'
+        '### {category}\n\n'
+        '{bullet}\n'
+    ).format(
+        tag=tag,
+        release_date=release_date,
+        category=category,
+        bullet=bullet,
+    )
+    release_notes = '### {0}\n\n{1}\n'.format(category, bullet)
+    return tag, changelog_entry, release_notes
+
+
+def insert_entry(changelog, tag, entry):
+    if re.search(r'^## \[{0}\](?:\s|-|\n)'.format(re.escape(tag)),
+                 changelog, re.MULTILINE):
+        return changelog
+
+    if not changelog.strip():
+        changelog = DEFAULT_CHANGELOG
+    if not changelog.endswith('\n'):
+        changelog += '\n'
+
+    unreleased = re.search(r'^## \[Unreleased\]\s*$',
+                           changelog, re.MULTILINE)
+    if unreleased:
+        following = changelog[unreleased.end():]
+        next_heading = re.search(r'^## \[', following, re.MULTILINE)
+        insert_at = (
+            unreleased.end() + next_heading.start()
+            if next_heading else len(changelog)
+        )
+    else:
+        first_release = re.search(r'^## \[', changelog, re.MULTILINE)
+        insert_at = first_release.start() if first_release else len(changelog)
+
+    before = changelog[:insert_at].rstrip()
+    after = changelog[insert_at:].lstrip('\n')
+    if after:
+        return '{0}\n\n{1}\n{2}'.format(before, entry.rstrip(), after)
+    return '{0}\n\n{1}\n'.format(before, entry.rstrip())
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--version', required=True)
+    parser.add_argument('--date', default=date.today().isoformat())
+    parser.add_argument('--pr-json', type=Path, required=True)
+    parser.add_argument('--changelog', type=Path, default=Path('CHANGELOG.md'))
+    parser.add_argument('--notes-file', type=Path)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    metadata = json.loads(args.pr_json.read_text(encoding='utf-8'))
+    tag, changelog_entry, release_notes = build_entries(
+        args.version,
+        args.date,
+        metadata,
+    )
+
+    changelog = (
+        args.changelog.read_text(encoding='utf-8')
+        if args.changelog.exists() else DEFAULT_CHANGELOG
+    )
+    args.changelog.write_text(
+        insert_entry(changelog, tag, changelog_entry),
+        encoding='utf-8',
+    )
+
+    if args.notes_file:
+        args.notes_file.write_text(release_notes, encoding='utf-8')
+
+    print(release_notes, end='')
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/bump-patch-version.yml
+++ b/.github/workflows/bump-patch-version.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: bump-patch-version-master
+  cancel-in-progress: false
+
 jobs:
   bump:
     name: Bump patch version
@@ -23,6 +27,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: master
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -55,30 +60,109 @@ jobs:
           echo "package_changed=$package_changed" >> "$GITHUB_OUTPUT"
           echo "version_changed=$version_changed" >> "$GITHUB_OUTPUT"
 
+      - name: Find existing automated bump
+        id: existing_bump
+        if: |
+          steps.package_changes.outputs.package_changed == 'true' &&
+          steps.package_changes.outputs.version_changed != 'true'
+        run: |
+          marker="^Automated-bump-for-pr: ${{ github.event.pull_request.number }}$"
+          sha="$(git log --format=%H --grep="$marker" -n 1)"
+          if [ -n "$sha" ]; then
+            version="$(
+              git show "$sha:pysm/version.py" |
+              python -c 'import sys; namespace = {}; exec(sys.stdin.read(), namespace); print(namespace["__version__"])'
+            )"
+            echo "processed=true" >> "$GITHUB_OUTPUT"
+            echo "sha=$sha" >> "$GITHUB_OUTPUT"
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+          else
+            echo "processed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Bump patch version
         id: bump
         if: |
           steps.package_changes.outputs.package_changed == 'true' &&
-          steps.package_changes.outputs.version_changed != 'true'
+          steps.package_changes.outputs.version_changed != 'true' &&
+          steps.existing_bump.outputs.processed != 'true'
         run: |
           version="$(python .github/scripts/bump_patch_version.py)"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Commit patch bump
+      - name: Skip already processed patch bump
+        if: steps.existing_bump.outputs.processed == 'true'
+        run: echo "This pull request already has an automated patch bump; ensuring the tag and release exist."
+
+      - name: Build changelog entry
         if: |
           steps.package_changes.outputs.package_changed == 'true' &&
           steps.package_changes.outputs.version_changed != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.bump.outputs.version || steps.existing_bump.outputs.version }}
         run: |
-          if git diff --quiet -- pysm/version.py; then
-            echo "No version change detected."
+          gh api \
+            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}" \
+            > /tmp/release-pr.json
+          python .github/scripts/prepend_changelog_entry.py \
+            --version "$VERSION" \
+            --date "$(date -u +%F)" \
+            --pr-json /tmp/release-pr.json \
+            --changelog CHANGELOG.md \
+            --notes-file /tmp/release-notes.md
+
+      - name: Commit patch bump
+        id: commit
+        if: |
+          steps.package_changes.outputs.package_changed == 'true' &&
+          steps.package_changes.outputs.version_changed != 'true' &&
+          steps.existing_bump.outputs.processed != 'true'
+        run: |
+          if git diff --quiet -- pysm/version.py CHANGELOG.md; then
+            echo "No version or changelog change detected."
+            echo "committed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add pysm/version.py
-          git commit -m "Bump patch version to ${{ steps.bump.outputs.version }} [skip ci]"
+          git add pysm/version.py CHANGELOG.md
+          git commit \
+            -m "Bump patch version to ${{ steps.bump.outputs.version }} [skip ci]" \
+            -m "Automated-bump-for-pr: ${{ github.event.pull_request.number }}"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "committed=true" >> "$GITHUB_OUTPUT"
           git push origin HEAD:master
+
+      - name: Create tag and GitHub release
+        if: |
+          steps.commit.outputs.committed == 'true' ||
+          steps.existing_bump.outputs.processed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.bump.outputs.version || steps.existing_bump.outputs.version }}
+          COMMIT_SHA: ${{ steps.commit.outputs.sha || steps.existing_bump.outputs.sha }}
+        run: |
+          tag="v$VERSION"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            git fetch --quiet --force origin "refs/tags/$tag:refs/tags/$tag"
+            tag_sha="$(git rev-list -n 1 "$tag")"
+            if [ "$tag_sha" != "$COMMIT_SHA" ]; then
+              echo "Tag $tag already exists at $tag_sha, expected $COMMIT_SHA."
+              exit 1
+            fi
+          else
+            git tag -a "$tag" -m "$tag" "$COMMIT_SHA"
+            git push origin "refs/tags/$tag"
+          fi
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag already exists."
+          else
+            gh release create "$tag" --title "$tag" --notes-file /tmp/release-notes.md
+          fi
 
       - name: Skip patch bump
         if: steps.package_changes.outputs.package_changed != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]


### PR DESCRIPTION
## Summary
- Add changelog generation for automated patch bumps
- Prevent duplicate bump jobs with workflow concurrency and existing-bump detection
- Create annotated tags and GitHub releases when a patch bump is committed

## Testing
- Not run (not requested)