### PR TITLE
Add changelog extraction and automated GitHub release workflow

### DIFF
--- a/.github/scripts/extract_changelog_entry.py
+++ b/.github/scripts/extract_changelog_entry.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+import argparse
+import re
+
+
+def normalize_version(version):
+    version = version.strip()
+    if version.startswith('v'):
+        return version[1:]
+    return version
+
+
+def extract_entry(changelog, version):
+    version = normalize_version(version)
+    pattern = re.compile(
+        r'^## \[v?{0}\][^\n]*\n(?P<body>.*?)(?=^## \[|\Z)'.format(
+            re.escape(version)),
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(changelog)
+    if not match:
+        raise SystemExit('No changelog entry found for version {0}'.format(
+            version))
+
+    body = match.group('body').strip()
+    if not body:
+        raise SystemExit('Changelog entry for version {0} is empty'.format(
+            version))
+    return body + '\n'
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--version', required=True)
+    parser.add_argument('--changelog', type=Path, default=Path('CHANGELOG.md'))
+    parser.add_argument('--output', type=Path)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    notes = extract_entry(
+        args.changelog.read_text(encoding='utf-8'),
+        args.version,
+    )
+
+    if args.output:
+        args.output.write_text(notes, encoding='utf-8')
+    else:
+        print(notes, end='')
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-master
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Create GitHub release
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check out master
+        uses: actions/checkout@v6
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Read package version
+        id: version
+        run: |
+          version="$(python -c 'namespace = {}; exec(open("pysm/version.py", encoding="utf-8").read(), namespace); print(namespace["__version__"])')"
+          tag="v$version"
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Build release notes
+        run: |
+          python .github/scripts/extract_changelog_entry.py \
+            --version "${{ steps.version.outputs.version }}" \
+            --changelog CHANGELOG.md \
+            --output /tmp/release-notes.md
+
+      - name: Create tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git fetch --quiet --tags origin
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            tag_sha="$(git rev-list -n 1 "$TAG")"
+            head_sha="$(git rev-parse HEAD)"
+            if [ "$tag_sha" != "$head_sha" ]; then
+              echo "Tag $TAG already exists at $tag_sha, expected $head_sha."
+              exit 1
+            fi
+            echo "Tag $TAG already exists at the current commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "$TAG"
+          git push origin "refs/tags/$TAG"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists."
+            exit 0
+          fi
+
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file /tmp/release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+## [0.4.0] - 2026-06-16
+
+### Added
+
+- Added opt-in queued, thread-safe queued, and async queued runtimes with run-to-completion semantics.
+- Added serialization helpers for capturing and restoring state machine snapshots.
+- Added a fluent builder API for constructing state machines.
+- Added type stubs and `py.typed` packaging metadata.
+- Added `initialize(fire_events_on_init=False)` support for firing initial enter handlers without changing the default behavior.
+
+### Changed
+
+- Modernized the package while keeping the classic core import small and dependency-free.
+- Refreshed documentation for core usage, optional modules, serialization, and MicroPython boundaries.
+
+### Fixed
+
+- Replaced dispatch-before-initialize assertions with clear `StateMachineException` errors.
+- Fixed MicroPython compatibility around unbounded deques, missing `logging`, and missing `collections.defaultdict`.
+
+### CI
+
+- Added GitHub Actions CI, package checks, a MicroPython Unix smoke job, and automatic patch-version bumping after merged package changes.


### PR DESCRIPTION
## Summary
- Add a script to extract release notes for a specific version from `CHANGELOG.md`
- Add a manual release workflow that tags the current version and publishes a GitHub release
- Include a changelog entry for `0.4.0`

## Testing
- Not run (not requested)