### PR TITLE
Document event propagation and MicroPython packaging

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -16,6 +16,68 @@ This is a simple state machine with only two states - `on` and `off`.
     :literal:
 
 
+Event input and fallback transitions
+------------------------------------
+
+Events can carry a separate ``input`` value. This is useful for parsers where
+many inputs share one event name. Use ``any_event`` when a state needs a
+fallback transition for a specific input regardless of the event name.
+
+.. code-block:: python
+
+    from pysm import Event, State, StateMachine, any_event
+
+    waiting = State('waiting')
+    digit = State('digit')
+    fallback = State('fallback')
+
+    machine = StateMachine('parser')
+    machine.add_state(waiting, initial=True)
+    machine.add_state(digit)
+    machine.add_state(fallback)
+    machine.add_transition(waiting, digit, events=['token'], input=['digit'])
+    machine.add_transition(
+        waiting, fallback, events=[any_event], input=['unknown'])
+    machine.initialize()
+
+    machine.dispatch(Event('token', input='unknown'))
+    assert machine.leaf_state is fallback
+
+
+Event propagation
+-----------------
+
+State handlers stop propagation by default. Set ``event.propagate`` back to
+``True`` when a child state should handle an event and then let a parent handle
+the same event too. ``enter`` and ``exit`` events never propagate.
+
+.. code-block:: python
+
+    from pysm import Event, State, StateMachine
+
+    calls = []
+    root = StateMachine('root')
+    child = StateMachine('child')
+    leaf = State('leaf')
+
+    def leaf_handler(state, event):
+        calls.append(state.name)
+        event.propagate = True
+
+    def child_handler(state, event):
+        calls.append(state.name)
+
+    leaf.handlers = {'bubble': leaf_handler}
+    child.handlers = {'bubble': child_handler}
+
+    root.add_state(child, initial=True)
+    child.add_state(leaf, initial=True)
+    root.initialize()
+
+    root.dispatch(Event('bubble'))
+    assert calls == ['leaf', 'child']
+
+
 Fluent builder
 --------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,11 @@ modules provide run-to-completion event scheduling, thread-safe dispatch,
 async dispatch, serialization, builder ergonomics, and shipped type
 information for editors and type checkers.
 
+Use ``pysm`` directly on regular Python. For MicroPython devices, install
+``upysm`` instead; it is the MicroPython distribution channel for selected
+``pysm`` releases, not a separate source fork. The installed package still
+imports as ``pysm``.
+
 The core runtime still follows the original composition-first style: create
 states, add them to a root machine, add transitions, initialize the machine,
 and dispatch hashable events. Newer helpers are layered around that core

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -19,6 +19,50 @@ The classic ``from pysm import StateMachine, State, Event`` import remains
 dependency-free; optional runtime helpers are imported from their own modules.
 
 
+MicroPython
+-----------
+
+Use ``upysm`` when installing the library on MicroPython. ``upysm`` is the
+MicroPython distribution channel for selected ``pysm`` releases; it is not a
+fork and does not carry separate application code. The installed package still
+imports as ``pysm``:
+
+.. code-block:: python
+
+    from pysm import Event, State, StateMachine
+
+Modern MicroPython installations should use ``mip`` through ``mpremote``:
+
+.. code-block:: console
+
+    mpremote mip install https://pgularski.github.io/upysm/
+
+Pin a specific release for repeatable device builds:
+
+.. code-block:: console
+
+    mpremote mip install https://pgularski.github.io/upysm/0.4.0/
+
+You can also install from the MicroPython REPL:
+
+.. code-block:: python
+
+    import mip
+    mip.install('https://pgularski.github.io/upysm/')
+
+Older firmware that still uses ``upip`` can install the package from PyPI:
+
+.. code-block:: python
+
+    import upip
+    upip.install('upysm')
+
+The default ``upysm`` build is core-focused. Optional modules such as
+``pysm.queued``, ``pysm.aio``, ``pysm.serialization``, and ``pysm.builder`` are
+documented for regular Python and should only be added to constrained device
+builds intentionally.
+
+
 Building the documentation locally
 ----------------------------------
 

--- a/docs/optional_modules.rst
+++ b/docs/optional_modules.rst
@@ -29,7 +29,7 @@ Core vs Optional Modules
    * - Queued runtime
      - ``from pysm.queued import QueuedStateMachine``
      - Run-to-completion event scheduling
-     - CPython-oriented optional module
+     - Not in the default ``upysm`` build
    * - Thread-safe queued runtime
      - ``from pysm.queued import ThreadSafeQueuedStateMachine``
      - Queued dispatch protected by ``threading.RLock``
@@ -65,6 +65,9 @@ hardening added a few details worth making visible:
   ``StateMachine`` instances are bounded by ``StateMachine.STACK_SIZE``. The
   default is ``32``. If you need an unbounded standalone stack, create
   ``Stack(maxlen=None)`` yourself.
+* Transition conditions are evaluated in registration order. A condition must
+  return the literal ``True`` to match; truthy values such as ``1`` do not
+  trigger the transition.
 * The core import does not load ``asyncio``, ``json``, ``threading``, or any of
   the optional ``pysm.*`` helper modules.
 
@@ -205,6 +208,21 @@ internal queue is empty. Use one event loop per machine.
 Use ``await machine.async_initialize(fire_events_on_init=True)`` if initial
 ``enter`` handlers need to be awaited.
 
+.. code-block:: python
+
+   calls = []
+   machine = AsyncQueuedStateMachine('m')
+   ready = State('ready')
+
+   async def on_enter_ready(state, event):
+       calls.append(state.name)
+
+   ready.handlers = {'enter': on_enter_ready}
+   machine.add_state(ready, initial=True)
+
+   await machine.async_initialize(fire_events_on_init=True)
+   assert calls == ['ready']
+
 
 Typed Packages
 --------------
@@ -287,16 +305,28 @@ String ``events`` and ``input`` values are treated as one event or input value,
 not as iterables of characters. Use a list, tuple, or other iterable when a
 single transition should match many values.
 
+``build()`` initializes the machine by default. Pass ``initialize=False`` when
+you want to finish setup with the core API and call ``initialize()`` yourself.
+
 
 MicroPython / upysm
 -------------------
 
-The MicroPython-oriented target should stay core-only:
+``upysm`` is the MicroPython distribution channel for selected ``pysm``
+releases. It is not a fork and does not provide a separate API; MicroPython
+installs still import the upstream package name:
 
 .. code-block:: python
 
    from pysm import StateMachine, State, Event
 
-Do not copy optional modules such as ``pysm.queued``, ``pysm.aio``,
-``pysm.serialization``, or ``pysm.builder`` into a constrained device build
-unless you explicitly need them and have measured the memory cost.
+The default ``upysm`` artifacts are built from the core runtime files
+(``pysm/__init__.py``, ``pysm/pysm.py``, and ``pysm/version.py``). This keeps
+the device package aligned with the upstream core while avoiding optional
+modules that pull in queues, ``threading``, ``asyncio``, serialization helpers,
+builder conveniences, or typing-only files.
+
+Do not add optional modules such as ``pysm.queued``, ``pysm.aio``,
+``pysm.serialization``, or ``pysm.builder`` to a constrained device build
+unless you explicitly need them and have measured the memory cost on your
+target firmware.


### PR DESCRIPTION
**Summary**
- Add examples for event input matching, fallback transitions, and bubbling event propagation.
- Clarify MicroPython installation via `upysm` and its relationship to the upstream `pysm` package.
- Update optional-module guidance and document transition condition behavior and async init examples.

**Testing**
- Not run (not requested)